### PR TITLE
Add password information and validation

### DIFF
--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -51,9 +51,8 @@
     "netmask_tooltip": "Do not change this value unless you know what you are doing. The field will be read-only after the first configuration",
     "netmask_helper": "The netmask determines the size of the VPN network. Use only class C networks",
     "password_placeholder": "Password can be modified from the controller webapp",
-    "password_information_title": "Password information",
-    "password_information_description": "The password is diplayed only once, please store it in a safe place",
-    "have_you_understood": "I have understood"
+    "password_information_title": "Default password",
+    "password_information_description": "The default administrator password is displayed only once, please store it in a safe place",
   },
   "about": {
     "title": "About"

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -23,6 +23,7 @@
   },
   "settings": {
     "title": "Settings",
+    "advanced": "Advanced",
     "configure_instance": "Configure {instance}",
     "save": "Save",
     "host": "Controller Fully Qualified Domain Name",

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -43,7 +43,7 @@
     "network_helper": "The VPN network used to connect the units to the controller.",
     "user_helper": "This is the only user that can create and manage other users inside the controller",
     "user_tooltip": "The username grants access to the controller user interface and also to Grafana. Once configured, it cannot be changed",
-    "password_helper": "The administrator password can be set only if first configuration",
+    "password_helper": "The administrator password can be set only during first configuration",
     "password_tooltip": "The password grants access both to the controller user interface and also to Grafana. For security reasons, you should change it after first login",
     "host_helper": "The FQDN of the controller, it must be reachable from the units",
     "cn_tooltip": "The field will be read-only after the first configuration",

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -50,7 +50,10 @@
     "network_tooltip": "Make sure this network does not overlap with the units' networks. The field will be read-only after the first configuration",
     "netmask_tooltip": "Do not change this value unless you know what you are doing. The field will be read-only after the first configuration",
     "netmask_helper": "The netmask determines the size of the VPN network. Use only class C networks",
-    "password_placeholder": "Password already set, enter a new one to change it"
+    "password_placeholder": "Password can be modified from the controller webapp",
+    "password_information_title": "Password information",
+    "password_information_description": "The password is diplayed only once, please store it in a safe place",
+    "have_you_understood": "I have understood"
   },
   "about": {
     "title": "About"

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -33,19 +33,47 @@
           $t("settings.netmask_tooltip")
         }}</template>
             </NsTextInput>
-
             <div class="mg-top-xxlg">
               <NsTextInput :label="$t('settings.user')" v-model="user" :placeholder="$t('settings.user')"
                 :disabled="loading.getConfiguration || loading.configureModule || !firstConfig" :invalid-message="error.user" ref="user"
                 :helper-text="$t('settings.user_helper')">
               <template #tooltip>{{$t("settings.user_tooltip")}}</template>
               </NsTextInput>
+              <cv-row v-if="firstConfig">
+                <cv-column>
+                  <NsInlineNotification
+                    class="mg-bottom-xlg"
+                    kind="info"
+                    :title="$t('settings.password_information_title')"
+                    :description="
+                      $t('settings.password_information_description')
+                    "
+                    :showCloseButton="false"
+                  >
+                   <NsButton></NsButton>
+                  </NsInlineNotification>
+                </cv-column>
+              </cv-row>
               <NsTextInput :label="$t('settings.password')" v-model="password"
                 :disabled="loading.getConfiguration || loading.configureModule || !firstConfig" :invalid-message="error.password"
                 :placeholder="passwordPlaceholder" ref="password" class="mg-bottom-xlg"
                 :helper-text="$t('settings.password_helper')">
               <template #tooltip>{{$t("settings.password_tooltip")}}</template>
               </NsTextInput>
+            </div>
+            <div class="mg-top-xxlg">
+              <NsTextInput :label="$t('settings.host')" v-model="host" placeholder="controller.mydomain.org"
+                :disabled="loading.getConfiguration || loading.configureModule" :invalid-message="error.host" ref="host"
+                :helper-text="$t('settings.host_helper')"></NsTextInput>
+              <cv-toggle value="letsEncrypt" :label="$t('settings.lets_encrypt')" v-model="lets_encrypt"
+                :disabled="loading.getConfiguration || loading.configureModule" class="mg-bottom">
+                <template slot="text-left">{{
+          $t("settings.disabled")
+        }}</template>
+                <template slot="text-right">{{
+            $t("settings.enabled")
+          }}</template>
+              </cv-toggle>
             </div>
             <!-- advanced options -->
             <cv-accordion ref="accordion" class="maxwidth mg-bottom">
@@ -75,20 +103,6 @@
               </cv-accordion-item>
             </cv-accordion>
             <!-- end advanced options -->
-            <div class="mg-top-xxlg">
-              <NsTextInput :label="$t('settings.host')" v-model="host" placeholder="controller.mydomain.org"
-                :disabled="loading.getConfiguration || loading.configureModule" :invalid-message="error.host" ref="host"
-                :helper-text="$t('settings.host_helper')"></NsTextInput>
-              <cv-toggle value="letsEncrypt" :label="$t('settings.lets_encrypt')" v-model="lets_encrypt"
-                :disabled="loading.getConfiguration || loading.configureModule" class="mg-bottom">
-                <template slot="text-left">{{
-          $t("settings.disabled")
-        }}</template>
-                <template slot="text-right">{{
-            $t("settings.enabled")
-          }}</template>
-              </cv-toggle>
-            </div>
 
             <cv-row v-if="error.configureModule">
               <cv-column>
@@ -414,4 +428,7 @@ export default {
 
 <style scoped lang="scss">
 @import "../styles/carbon-utils";
+.mg-bottom {
+  margin-bottom: 2rem;
+}
 </style>

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -15,13 +15,6 @@
       <cv-column>
         <cv-tile light>
           <cv-form @submit.prevent="configureModule">
-            <NsTextInput :label="$t('settings.cn')" v-model="cn" :placeholder="$t('settings.cn')" :disabled="loading.getConfiguration ||
-          loading.configureModule ||
-          !firstConfig" :helper-text="$t('settings.cn_helper')" tooltipAlignment="end" tooltipDirection="right">
-              <template #tooltip>{{
-          $t("settings.cn_tooltip")
-        }}</template>
-            </NsTextInput>
             <NsTextInput :label="$t('settings.network')" v-model="network" :placeholder="$t('settings.network')"
               :disabled="loading.getConfiguration ||
           loading.configureModule ||
@@ -54,21 +47,34 @@
               <template #tooltip>{{$t("settings.password_tooltip")}}</template>
               </NsTextInput>
             </div>
-            <div class="mg-top-xxlg">
-              <NsTextInput v-model.trim="loki_retention" ref="loki_retention"
-                :invalid-message="$t(error.loki_retention)" type="number" :label="$t('settings.loki_retention')"
-                :helper-text="$t('settings.loki_retention_helper')
-          " :disabled="loading.configureModule
-          ">
-              </NsTextInput>
-              <NsTextInput v-model.trim="prometheus_retention" ref="prometheus_retention"
-                :invalid-message="$t(error.prometheus_retention)" type="number"
-                :label="$t('settings.prometheus_retention')" :helper-text="$t('settings.prometheus_retention_helper')
-          " :disabled="loading.configureModule
-          ">
-              </NsTextInput>
-            </div>
-
+            <!-- advanced options -->
+            <cv-accordion ref="accordion" class="maxwidth mg-bottom">
+              <cv-accordion-item :open="toggleAccordion[0]">
+                <template slot="title">{{ $t("settings.advanced") }}</template>
+                <template slot="content">
+                  <div class="mg-top-xxlg">
+                    <NsTextInput :label="$t('settings.cn')" v-model="cn" :placeholder="$t('settings.cn')" :disabled="loading.getConfiguration ||
+                      loading.configureModule ||
+                      !firstConfig" :helper-text="$t('settings.cn_helper')" tooltipAlignment="end" tooltipDirection="right">
+                    <template #tooltip>{{
+                      $t("settings.cn_tooltip")
+                    }}</template>
+                    </NsTextInput>
+                    <NsTextInput v-model.trim="loki_retention" ref="loki_retention"
+                      :invalid-message="$t(error.loki_retention)" type="number" :label="$t('settings.loki_retention')"
+                      :helper-text="$t('settings.loki_retention_helper')"
+                      :disabled="loading.configureModule">
+                    </NsTextInput>
+                    <NsTextInput v-model.trim="prometheus_retention" ref="prometheus_retention"
+                      :invalid-message="$t(error.prometheus_retention)" type="number"
+                      :label="$t('settings.prometheus_retention')" :helper-text="$t('settings.prometheus_retention_helper')"
+                      :disabled="loading.configureModule">
+                    </NsTextInput>
+                  </div>
+                </template>
+              </cv-accordion-item>
+            </cv-accordion>
+            <!-- end advanced options -->
             <div class="mg-top-xxlg">
               <NsTextInput :label="$t('settings.host')" v-model="host" placeholder="controller.mydomain.org"
                 :disabled="loading.getConfiguration || loading.configureModule" :invalid-message="error.host" ref="host"


### PR DESCRIPTION
This pull request adds password information and validation to the UI. It includes changes to the translation file and the Settings.vue file. 

The translation file now includes a new password placeholder and additional password information. 

The Settings.vue file has been updated to display a warning message about the password and to include advanced options in an accordion.

REFs
https://github.com/NethServer/dev/issues/6953


![image](https://github.com/NethServer/ns8-nethsecurity-controller/assets/3164851/2fbe6245-52d5-4afc-bbd7-6174b96cfbad)
![image](https://github.com/NethServer/ns8-nethsecurity-controller/assets/3164851/7bdc03c7-9467-475b-88a1-1f19ea9df7d9)
![image](https://github.com/NethServer/ns8-nethsecurity-controller/assets/3164851/ff0c4e01-5522-4414-9e3d-7249402b749d)

