### PR TITLE
Add maxwidth class to notification

### DIFF
--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -42,7 +42,7 @@
               <cv-row v-if="firstConfig">
                 <cv-column>
                   <NsInlineNotification
-                    class="mg-bottom-xlg"
+                    class="mg-bottom-xlg maxwidth"
                     kind="info"
                     :title="$t('settings.password_information_title')"
                     :description="
@@ -430,5 +430,8 @@ export default {
 @import "../styles/carbon-utils";
 .mg-bottom {
   margin-bottom: 2rem;
+}
+.maxwidth {
+  max-width: 38rem;
 }
 </style>


### PR DESCRIPTION
This pull request adds the `maxwidth` class to the notification in the Settings view. This class sets the maximum width of the notification to 38rem, ensuring that the notification does not exceed a certain width. This improves the overall layout and readability of the notification.

https://github.com/NethServer/dev/issues/6953