### PR TITLE
chore: version bump

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -9,7 +9,7 @@ images=()
 repobase="${REPOBASE:-ghcr.io/nethserver}"
 # Configure the image name
 reponame="nethsecurity-controller"
-controller_version="0.0.34"
+controller_version="main"
 promtail_version=2.7.1
 loki_version=2.9.4
 prometheus_version=2.50.1


### PR DESCRIPTION
Pre-checking the release and allowing testing in https://github.com/NethServer/nethsecurity/issues/721
