### PR TITLE
Show OpenVPN port in the app Status section

### DIFF
--- a/imageroot/actions/get-configuration/20read
+++ b/imageroot/actions/get-configuration/20read
@@ -21,6 +21,8 @@ if os.path.isfile('config.json'):
 
     # Cleanup password hash to avoid changes from the UI
     config['api_password'] = ''
+    network = agent.read_envfile('network.env')
+    config['vpn_port'] = network['OVPN_UDP_PORT']
 else:
     # Prepare random values for first-configuration
     # Pick a newtork inside 172.16.0.0/12 (range 172.16.0.0-172.31.255.255)

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -19,7 +19,8 @@
     "no_services": "No services",
     "no_images": "No images",
     "no_volumes": "No volumes",
-    "open_controller": "Open Controller"
+    "open_controller": "Open Controller",
+    "ovpn_udp_port": "OpenVPN UDP port"
   },
   "settings": {
     "title": "Settings",

--- a/ui/src/views/Status.vue
+++ b/ui/src/views/Status.vue
@@ -41,6 +41,17 @@
           class="min-height-card" />
       </cv-column>
       <cv-column :md="4" :max="4">
+        <NsInfoCard
+          light
+          :title="$t('status.ovpn_udp_port')"
+          :description="vpn_port"
+          :icon="Network_232"
+          :loading="loading.getConfiguration"
+          class="min-height-card"
+        >
+        </NsInfoCard>
+      </cv-column>
+      <cv-column :md="4" :max="4">
         <NsBackupCard :title="core.$t('backup.title')" :noBackupMessage="core.$t('backup.no_backup_configured')"
           :goToBackupLabel="core.$t('backup.go_to_backup')" :repositoryLabel="core.$t('backup.repository')"
           :statusLabel="core.$t('common.status')" :statusSuccessLabel="core.$t('common.success')"
@@ -465,6 +476,7 @@ export default {
     getConfigurationCompleted(taskContext, taskResult) {
       this.loading.getConfiguration = false;
       this.host = taskResult.output.host;
+      this.vpn_port = taskResult.output.vpn_port;
     },
     goToControllerApp() {
       window.open(`https://${this.host}`, "_blank");


### PR DESCRIPTION
Added the UDP port of the server’s VPN endpoint to the status page in the NethServer UI. This enhancement simplifies identifying the port that needs to be opened in the firewall for VPN connections.

![image](https://github.com/user-attachments/assets/ef852364-6b7b-4100-85bc-8d6bd6f92af4)
![image](https://github.com/user-attachments/assets/7b7b5795-59db-46e5-a347-a961cb88b51b)


https://github.com/NethServer/dev/issues/7059