### PR TITLE
Rename SQL dump output file to backup.sql

### DIFF
--- a/imageroot/bin/module-dump-state
+++ b/imageroot/bin/module-dump-state
@@ -6,4 +6,4 @@ set -e
 . ./db.env
 
 # Dump the DB from timescale
-podman exec -i timescale pg_dump -U "${POSTGRES_USER}" -p "${POSTGRES_PORT}" > timescale.sql
+podman exec -i timescale pg_dump -U "${POSTGRES_USER}" -p "${POSTGRES_PORT}" > backup.sql


### PR DESCRIPTION
Rename the SQL dump output file from `timescale.sql` to `backup.sql` to fix the restoration issue

https://github.com/NethServer/dev/issues/7203


- what it works: restore on the same node
do a backup of the controller with an attached nethsecurity instance
restore the backup on the same node and replace the ns8-nethsecurity-controller instance
the restoration goes well
the NethSecurity instance is not seen online from the controller
inside the NethSecurity, we see the controller online
restart the Nethsecurity connection inside the controller menu of NethSecurity  and the instance is seen online inside the controller

The restart of NethSecurity seems a mandatory


 - what it does not work without manual interaction: restore on another node
do a backup of the controller with an attached nethsecurity instance
restore the backup on another  node and replace the ns8-nethsecurity-controller instance
the restoration goes well
the NethSecurity instance is not seen online from the controller
inside the NethSecurity, we do not see the controller online
set a new FQDN to the controller because the FQDN now must be  on the node2
disconnect the Nethsecurity instance from the controller
disconnect the controller from the NethSecurity instance
try to reconnect the NethSecurity with another join code
From the connector the NethSecurity is seen  registered
From the NethSecurity the status is seen connected

