### PR TITLE
fix(systemd): make sure controller is started

### DIFF
--- a/imageroot/systemd/user/metrics-exporter.path
+++ b/imageroot/systemd/user/metrics-exporter.path
@@ -2,6 +2,7 @@
 Description=Watch for vpn connections from vpn.service
 BindsTo=controller.service
 After=vpn.service
+DefaultDependencies=no
 
 [Path]
 PathChanged=%S/state/clients


### PR DESCRIPTION
Sometimes, the controller could be not started after a reboot. The error was:
Job metrics-exporter.path/start deleted to break ordering cycle starting with paths.target/start