### PR TITLE
fix(create-module): do not set SECRET_JWT

### DIFF
--- a/imageroot/actions/create-module/20initialize
+++ b/imageroot/actions/create-module/20initialize
@@ -42,7 +42,6 @@ WEBSSH_PORT=$webssh_port
 EOF
 
 cat << EOF > secret.env
-SECRET_JWT=$jwt_secret
 REGISTRATION_TOKEN=$reg_secret
 EOF
 


### PR DESCRIPTION
The SECRET_JWT variable is regenerated at each container start

NethServer/dev#7251

See also: https://github.com/NethServer/nethsecurity-controller/pull/78