### PR TITLE
Update url of documentation

### DIFF
--- a/ui/public/metadata.json
+++ b/ui/public/metadata.json
@@ -12,7 +12,7 @@
     }
   ],
   "docs": {
-    "documentation_url": "https://docs.nethsecurity.org/",
+    "documentation_url": "https://docs.nethserver.org/projects/ns8/en/latest/nethsecurity_controller.html",
     "bug_url": "https://github.com/NethServer/nethsecurity/issues",
     "code_url": "https://github.com/NethServer/ns8-nethsecurity-controller"
   },


### PR DESCRIPTION
This pull request updates the documentation URL in the `ui/public/metadata.json` file to point to a more specific and current location.

* [`ui/public/metadata.json`](diffhunk://#diff-57394ba6289dada95fe587665ef1b86264521bc888ccdaa69d5994e96f1ea77dL15-R15): Updated the `documentation_url` to `https://docs.nethserver.org/projects/ns8/en/latest/nethsecurity_controller.html` for improved accuracy and relevance.

https://github.com/NethServer/dev/issues/7399