### PR TITLE
perf: removed relabeling for high inode volumes

### DIFF
--- a/imageroot/systemd/user/loki.service
+++ b/imageroot/systemd/user/loki.service
@@ -15,7 +15,7 @@ ExecStart=/usr/bin/podman run \
     --cgroups=no-conmon \
     --pod-id-file %t/controller.pod-id \
     --replace -d --name loki \
-    --volume=loki-data:/loki:z \
+    --volume=loki-data:/loki \
     --volume %S/etc/loki.yaml:/etc/loki/local-config.yaml:z \
     --network=host \
     --env-file=%S/state/loki.env \

--- a/imageroot/systemd/user/timescale.service
+++ b/imageroot/systemd/user/timescale.service
@@ -18,7 +18,7 @@ ExecStart=/usr/bin/podman run \
     --cgroups=no-conmon \
     --pod-id-file %t/controller.pod-id \
     --replace -d --name timescale \
-    --volume=timescale-data:/var/lib/postgresql/data:z \
+    --volume=timescale-data:/var/lib/postgresql/data \
     --env-file=%S/state/db.env \
     --network=host \
     ${TIMESCALEDB_IMAGE} -p ${POSTGRES_PORT} -h 127.0.0.1


### PR DESCRIPTION
It seems there're some issues with starting containers if they have high iops and relabeling enabled. Removing it from affected storages.

Ref: https://mattermost.nethesis.it/nethesis/pl/hnsy5nrh8bd9xnfeosftgsuwxa
