### PR TITLE
Fix controller restore during database import

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,31 @@ systemctl --user restart controller.service
 
 ## Troubleshooting
 
+### Restarting the controller
+
+The controller runs as a systemd user unit (controller.service) that creates the Podman pod hosting the other containers. The controller unit Requires and is ordered Before the following services: vpn.service, api.service, ui.service, proxy.service, promtail.service, loki.service, prometheus.service, grafana.service, webssh.service and timescale.service.
+
+Quick restart, recommended for support operations:
+
+    runagent -m nethsecurity-controller1
+    systemctl --user restart controller.service
+
+This will stop and recreate the Podman pod and will trigger the dependent services to be (re)started.
+
+To pause the service, proceed with an ordered stop of the dependent services, then stop the controller:
+
+    runagent -m nethsecurity-controller1
+    systemctl --user disable --now timescale api grafana loki prometheus promtail proxy ui vpn webssh
+    systemctl --user disable --now controller.service
+
+You can resume the service with an ordered start of the controller and dependent services:
+
+    runagent -m nethsecurity-controller1
+    systemctl --user enable controller.service
+    systemctl --user restart controller.service
+
+Replace 'nethsecurity-controller1' with your instance name.
+
 ### Logs
 
 To see al logs from the controller using the command line, execute this command con the node where the controller is running:

--- a/imageroot/actions/configure-module/20configure
+++ b/imageroot/actions/configure-module/20configure
@@ -90,7 +90,6 @@ set_route_data = {
     'instance': os.environ['MODULE_ID'] + '_webssh',
     'url':  f'http://127.0.0.1:{ports[9]}',
     'http2https': True,
-    'lets_encrypt': request["lets_encrypt"],
     'host': request["host"],
     'path': config['webssh_path'],
     'strip_prefix': True,

--- a/imageroot/actions/destroy-module/50systemd
+++ b/imageroot/actions/destroy-module/50systemd
@@ -8,4 +8,5 @@
 exec 1>&2 # Send any output to stderr, to not alter the action response protocol
 
 # Stop the controller to free the tun device
+systemctl --user disable --now timescale api grafana loki prometheus promtail proxy ui vpn webssh
 systemctl --user disable --now controller.service

--- a/imageroot/actions/restore-module/30restore_database
+++ b/imageroot/actions/restore-module/30restore_database
@@ -8,5 +8,7 @@ until podman exec timescale pg_isready -U "${POSTGRES_USER}" -p "${POSTGRES_PORT
   sleep 5
 done
 
-# Dump the DB from timescale
-podman exec -i timescale psql -U "${POSTGRES_USER}" -p "${POSTGRES_PORT}" < backup.sql
+# Load dump avoiding issues on timescaledb hypertables
+podman exec timescale psql -U "${POSTGRES_USER}" -p "${POSTGRES_PORT}" -d "${POSTGRES_DB}" -c "CREATE EXTENSION IF NOT EXISTS timescaledb; SELECT timescaledb_pre_restore();"
+podman exec timescale psql -U "${POSTGRES_USER}" -p "${POSTGRES_PORT}" < backup.sql
+podman exec timescale psql -U "${POSTGRES_USER}" -p "${POSTGRES_PORT}" -d "${POSTGRES_DB}" -c "SELECT timescaledb_post_restore();"

--- a/imageroot/actions/restore-module/30restore_database
+++ b/imageroot/actions/restore-module/30restore_database
@@ -10,5 +10,5 @@ done
 
 # Load dump avoiding issues on timescaledb hypertables
 podman exec timescale psql -U "${POSTGRES_USER}" -p "${POSTGRES_PORT}" -d "${POSTGRES_DB}" -c "CREATE EXTENSION IF NOT EXISTS timescaledb; SELECT timescaledb_pre_restore();"
-podman exec timescale psql -U "${POSTGRES_USER}" -p "${POSTGRES_PORT}" < backup.sql
+cat backup.dump | podman exec -i timescale pg_restore  -Fc -U "${POSTGRES_USER}" -p "${POSTGRES_PORT}"  -d "${POSTGRES_DB}"
 podman exec timescale psql -U "${POSTGRES_USER}" -p "${POSTGRES_PORT}" -d "${POSTGRES_DB}" -c "SELECT timescaledb_post_restore();"

--- a/imageroot/bin/module-cleanup-state
+++ b/imageroot/bin/module-cleanup-state
@@ -2,4 +2,4 @@
 
 set -e
 
-rm -f backup.sql
+rm -f backup.dump

--- a/imageroot/bin/module-dump-state
+++ b/imageroot/bin/module-dump-state
@@ -6,4 +6,4 @@ set -e
 . ./db.env
 
 # Dump the DB from timescale
-podman exec -i timescale pg_dump -U "${POSTGRES_USER}" -p "${POSTGRES_PORT}" > backup.sql
+podman exec timescale pg_dump -Fc -U "${POSTGRES_USER}" -p "${POSTGRES_PORT}" > backup.dump

--- a/imageroot/etc/state-include.conf
+++ b/imageroot/etc/state-include.conf
@@ -6,4 +6,4 @@ volumes/api-credentials
 volumes/api-data
 state/secret.env
 state/config.json
-state/backup.sql
+state/backup.dump

--- a/imageroot/systemd/user/api.service
+++ b/imageroot/systemd/user/api.service
@@ -1,7 +1,7 @@
 
 [Unit]
 Description=Podman api.service
-BindsTo=controller.service
+Wants=controller.service
 After=controller.service vpn.service timescale.service
 
 [Service]

--- a/imageroot/systemd/user/grafana.service
+++ b/imageroot/systemd/user/grafana.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Podman grafana.service
-BindsTo=controller.service
+Wants=controller.service
 After=promethus.service
 After=loki.service
 

--- a/imageroot/systemd/user/loki.service
+++ b/imageroot/systemd/user/loki.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Podman loki.service
-BindsTo=controller.service
+Wants=controller.service
 Before=promtail.service
 
 [Service]

--- a/imageroot/systemd/user/prometheus.service
+++ b/imageroot/systemd/user/prometheus.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Podman prometheus.service
-BindsTo=controller.service
+Wants=controller.service
 After=vpn.service
 
 [Service]

--- a/imageroot/systemd/user/promtail.service
+++ b/imageroot/systemd/user/promtail.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Podman promtail.service
-BindsTo=controller.service
+Wants=controller.service
 After=vpn.service
 
 [Service]

--- a/imageroot/systemd/user/proxy.service
+++ b/imageroot/systemd/user/proxy.service
@@ -1,7 +1,7 @@
 
 [Unit]
 Description=Podman proxy.service
-BindsTo=controller.service
+Wants=controller.service
 After=api.service vpn.service 
 Requires=api.service vpn.service
 

--- a/imageroot/systemd/user/timescale.service
+++ b/imageroot/systemd/user/timescale.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Podman timescale.service
-BindsTo=controller.service
 Before=api.service
+Wants=controller.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n

--- a/imageroot/systemd/user/ui.service
+++ b/imageroot/systemd/user/ui.service
@@ -1,7 +1,7 @@
 
 [Unit]
 Description=Podman ui.service
-BindsTo=controller.service
+Wants=controller.service
 After=api.service
 Requires=api.service
 

--- a/imageroot/systemd/user/vpn.service
+++ b/imageroot/systemd/user/vpn.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Podman vpn.service
-BindsTo=controller.service
+Wants=controller.service
 After=controller.service
 
 [Service]

--- a/imageroot/systemd/user/webssh.service
+++ b/imageroot/systemd/user/webssh.service
@@ -1,7 +1,7 @@
 
 [Unit]
 Description=Podman webssh.service
-BindsTo=controller.service
+Wants=controller.service
 After=vpn.service
 
 [Service]

--- a/imageroot/update-module.d/90update_timescale
+++ b/imageroot/update-module.d/90update_timescale
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2026 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+# Upgrade TimescaleDB in place after the module image restart.
+
+set -e
+
+if [ ! -f "./db.env" ]; then
+    exit 0
+fi
+
+. ./db.env
+
+if [ -z "${REPORT_DB_URI}" ]; then
+    echo "REPORT_DB_URI is missing, skipping TimescaleDB update" >&2
+    exit 0
+fi
+
+until podman exec timescale pg_isready -d "${REPORT_DB_URI}"; do
+    sleep 5
+done
+
+podman exec timescale psql "${REPORT_DB_URI}" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION IF NOT EXISTS timescaledb;"
+
+current_version=$(podman exec timescale psql "${REPORT_DB_URI}" -Atqc "SELECT COALESCE((SELECT extversion FROM pg_extension WHERE extname = 'timescaledb'), '');")
+target_version=$(podman exec timescale psql "${REPORT_DB_URI}" -Atqc "SELECT default_version FROM pg_available_extensions WHERE name = 'timescaledb';")
+
+if [ -z "${target_version}" ]; then
+    echo "Unable to read the installed TimescaleDB default version" >&2
+    exit 1
+fi
+
+if [ "${current_version}" != "${target_version}" ]; then
+    podman exec timescale psql "${REPORT_DB_URI}" -v ON_ERROR_STOP=1 -c "ALTER EXTENSION timescaledb UPDATE TO '${target_version}';"
+fi
+
+podman exec timescale psql "${REPORT_DB_URI}" -v ON_ERROR_STOP=1 -c "\dx timescaledb;"


### PR DESCRIPTION
## Summary

- preserve the backed-up `lets_encrypt` value during restore instead of stripping it before `configure-module`: Let's Encrypt configuration is bound to Traefik configuration and it's not restored
- apply Timescale extension upgrade: this is requires, otherwise it's not possible to restore a database dump executed on an old version of Timescale
- change backup format to custom Postgres binary format and enforce Timescale best practices during restore: https://www.tigerdata.com/docs/deploy/self-hosted/backup-and-restore/logical-backup
- remove `BindsTo` option inside systemd units: with this option, if a service fails during restore, all systemd units are stopped and the database restore fails


Testing the fix:
```
# same timescale, schema and backup fixed
api-cli run update-module --data '{"module_url":"ghcr.io/nethserver/nethsecurity-controller:issue1646","instances":["nethsecurity-controller22"], "force": true}'
```

## Related issue

NethServer/nethsecurity#1646

## How to test

1. On a machine where the module should be restored:
   ```
   podman pull ghcr.io/nethserver/nethsecurity-controller:issue1646
   podman tag 540ccfb6c4f9 ghcr.io/nethserver/nethsecurity-controller:2.2.4
   podman tag 540ccfb6c4f9 ghcr.io/nethserver/nethsecurity-controller:2.2.3
   ```
2. Proceed with the restore