### PR TITLE
fix(systemd): replace %S with %E in unit files

### DIFF
--- a/imageroot/systemd/user/api.service
+++ b/imageroot/systemd/user/api.service
@@ -6,7 +6,7 @@ After=controller.service vpn.service timescale.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
+EnvironmentFile=%E/state/environment
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/api.pid %t/api.ctr-id
@@ -21,14 +21,14 @@ ExecStart=/usr/bin/podman run \
     --volume api-secrets:/nethsecurity-api/secrets/:z \
     --volumes-from=vpn \
     --network=host \
-    --env-file=%S/state/network.env \
-    --env-file=%S/state/secret.env \
-    --env-file=%S/state/config.env \
-    --env-file=%S/state/promtail.env \
-    --env-file=%S/state/subscription.env \
-    --env-file=%S/state/db.env \
-    --env-file=%S/state/platform.env \
-    --env-file=%S/state/api.env \
+    --env-file=%E/state/network.env \
+    --env-file=%E/state/secret.env \
+    --env-file=%E/state/config.env \
+    --env-file=%E/state/promtail.env \
+    --env-file=%E/state/subscription.env \
+    --env-file=%E/state/db.env \
+    --env-file=%E/state/platform.env \
+    --env-file=%E/state/api.env \
     ${NETHSECURITY_API_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/api.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/api.ctr-id

--- a/imageroot/systemd/user/controller.service
+++ b/imageroot/systemd/user/controller.service
@@ -2,12 +2,12 @@
 Description=Podman controller.service
 Requires=vpn.service api.service ui.service proxy.service promtail.service loki.service prometheus.service grafana.service webssh.service timescale.service
 Before=vpn.service api.service ui.service proxy.service promtail.service loki.service prometheus.service grafana.service webssh.service timescale.service
-ConditionPathExists=%S/state/environment
-ConditionPathExists=%S/state/network.env
+ConditionPathExists=%E/state/environment
+ConditionPathExists=%E/state/network.env
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
+EnvironmentFile=%E/state/environment
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/controller.pid %t/controller.pod-id

--- a/imageroot/systemd/user/grafana.service
+++ b/imageroot/systemd/user/grafana.service
@@ -6,7 +6,7 @@ After=loki.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
+EnvironmentFile=%E/state/environment
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/grafana.pid %t/grafana.ctr-id
@@ -18,11 +18,11 @@ ExecStart=/usr/bin/podman run \
     --pod-id-file %t/controller.pod-id \
     --replace -d --name grafana \
     --volume grafana-data:/var/lib/grafana:z \
-    --volume=%S/state/grafana.yml:/etc/grafana/provisioning/datasources/local.yml:z \
-    --volume=%S/etc/dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml:z \
-    --volume=%S/etc/dashboards/:/etc/grafana/dashboards:z \
+    --volume=%E/state/grafana.yml:/etc/grafana/provisioning/datasources/local.yml:z \
+    --volume=%E/etc/dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml:z \
+    --volume=%E/etc/dashboards/:/etc/grafana/dashboards:z \
     --network=host \
-    --env-file=%S/state/grafana.env \
+    --env-file=%E/state/grafana.env \
     ${GRAFANA_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/grafana.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/grafana.ctr-id

--- a/imageroot/systemd/user/loki.service
+++ b/imageroot/systemd/user/loki.service
@@ -5,7 +5,7 @@ Before=promtail.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
+EnvironmentFile=%E/state/environment
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/loki.pid %t/loki.ctr-id
@@ -16,9 +16,9 @@ ExecStart=/usr/bin/podman run \
     --pod-id-file %t/controller.pod-id \
     --replace -d --name loki \
     --volume=loki-data:/loki \
-    --volume %S/etc/loki.yaml:/etc/loki/local-config.yaml:z \
+    --volume %E/etc/loki.yaml:/etc/loki/local-config.yaml:z \
     --network=host \
-    --env-file=%S/state/loki.env \
+    --env-file=%E/state/loki.env \
     ${LOKI_IMAGE} \
     -config.expand-env=true \
     -config.file=/etc/loki/local-config.yaml \

--- a/imageroot/systemd/user/prometheus.service
+++ b/imageroot/systemd/user/prometheus.service
@@ -5,9 +5,9 @@ After=vpn.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
-EnvironmentFile=%S/state/prometheus.env
-WorkingDirectory=%S/state
+EnvironmentFile=%E/state/environment
+EnvironmentFile=%E/state/prometheus.env
+WorkingDirectory=%E/state
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/prometheus.pid %t/prometheus.ctr-id
@@ -18,8 +18,8 @@ ExecStart=/usr/bin/podman run \
     --cgroups=no-conmon \
     --pod-id-file %t/controller.pod-id \
     --replace -d --name prometheus \
-    --volume=%S/state/prometheus.yml:/prometheus/prometheus.yml:z \
-    --volume=%S/state/web.yml:/prometheus/web.yml:z \
+    --volume=%E/state/prometheus.yml:/prometheus/prometheus.yml:z \
+    --volume=%E/state/web.yml:/prometheus/web.yml:z \
     --volume=prometheus-data:/prometheus:z \
     --network=host \
     ${PROMETHEUS_IMAGE} --web.listen-address=127.0.0.1:${PROMETHEUS_PORT} --web.external-url=${PROMETHEUS_PATH} --storage.tsdb.retention.time=${PROMETHEUS_RETENTION} --web.config.file=/prometheus/web.yml

--- a/imageroot/systemd/user/promtail.service
+++ b/imageroot/systemd/user/promtail.service
@@ -5,7 +5,7 @@ After=vpn.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
+EnvironmentFile=%E/state/environment
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/promtail.pid %t/promtail.ctr-id
@@ -15,10 +15,10 @@ ExecStart=/usr/bin/podman run \
     --cgroups=no-conmon \
     --pod-id-file %t/controller.pod-id \
     --replace -d --name promtail \
-    --volume %S/etc/promtail.yml:/etc/promtail/config.yml:z \
+    --volume %E/etc/promtail.yml:/etc/promtail/config.yml:z \
     --network=host \
-    --env-file=%S/state/promtail.env \
-    --env-file=%S/state/config.env \
+    --env-file=%E/state/promtail.env \
+    --env-file=%E/state/config.env \
     ${PROMTAIL_IMAGE} \
     -config.expand-env=true -config.file=/etc/promtail/config.yml
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/promtail.ctr-id -t 10

--- a/imageroot/systemd/user/proxy.service
+++ b/imageroot/systemd/user/proxy.service
@@ -7,7 +7,7 @@ Requires=api.service vpn.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
+EnvironmentFile=%E/state/environment
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/.pid %t/proxy.ctr-id
@@ -19,7 +19,7 @@ ExecStart=/usr/bin/podman run \
     --replace -d --name proxy \
     --volumes-from=vpn \
     --network=host \
-    --env-file=%S/state/network.env \
+    --env-file=%E/state/network.env \
     ${NETHSECURITY_PROXY_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/proxy.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/proxy.ctr-id

--- a/imageroot/systemd/user/timescale.service
+++ b/imageroot/systemd/user/timescale.service
@@ -5,10 +5,10 @@ Wants=controller.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
-EnvironmentFile=%S/state/secret.env
-EnvironmentFile=%S/state/db.env
-WorkingDirectory=%S/state
+EnvironmentFile=%E/state/environment
+EnvironmentFile=%E/state/secret.env
+EnvironmentFile=%E/state/db.env
+WorkingDirectory=%E/state
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/timescale.pid %t/timescale.ctr-id
@@ -19,7 +19,7 @@ ExecStart=/usr/bin/podman run \
     --pod-id-file %t/controller.pod-id \
     --replace -d --name timescale \
     --volume=timescale-data:/var/lib/postgresql/data \
-    --env-file=%S/state/db.env \
+    --env-file=%E/state/db.env \
     --network=host \
     ${TIMESCALEDB_IMAGE} -p ${POSTGRES_PORT} -h 127.0.0.1
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/timescale.ctr-id -t 10

--- a/imageroot/systemd/user/ui.service
+++ b/imageroot/systemd/user/ui.service
@@ -7,7 +7,7 @@ Requires=api.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
+EnvironmentFile=%E/state/environment
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/.pid %t/ui.ctr-id
@@ -18,7 +18,7 @@ ExecStart=/usr/bin/podman run \
     --pod-id-file %t/controller.pod-id \
     --replace -d --name ui \
     --network=host \
-    --env-file=%S/state/network.env \
+    --env-file=%E/state/network.env \
     ${NETHSECURITY_UI_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/ui.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/ui.ctr-id

--- a/imageroot/systemd/user/vpn.service
+++ b/imageroot/systemd/user/vpn.service
@@ -5,7 +5,7 @@ After=controller.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
+EnvironmentFile=%E/state/environment
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/vpn.pid %t/vpn.ctr-id
@@ -16,8 +16,8 @@ ExecStart=/usr/bin/podman run \
     --pod-id-file %t/controller.pod-id \
     --replace -d --name vpn \
     -v vpn-data:/etc/openvpn/:z \
-    --env-file=%S/state/network.env \
-    --env-file=%S/state/config.env \
+    --env-file=%E/state/network.env \
+    --env-file=%E/state/config.env \
     --network=host --device /dev/net/tun \
     --security-opt label=disable \
     ${NETHSECURITY_VPN_IMAGE}

--- a/imageroot/systemd/user/webssh.service
+++ b/imageroot/systemd/user/webssh.service
@@ -6,8 +6,8 @@ After=vpn.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
-EnvironmentFile=%S/state/network.env
+EnvironmentFile=%E/state/environment
+EnvironmentFile=%E/state/network.env
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/.pid %t/webssh.ctr-id


### PR DESCRIPTION
## Summary
- Newer systemd releases (Rocky Linux 9.8+, Debian 13) changed the `%S` specifier to expand to `~/.local/state` instead of `~/.config`, breaking units that relied on the old behavior to reference the config/state directory.
- Replaced `%S` with `%E` across all affected systemd user unit files. `%E` expands to `~/.config` on both old and new systemd, making the units forward-compatible.

Related: NethServer/dev#8029

## Test plan
- [ ] Verify units still parse (`systemd-analyze verify`) on a test node
- [ ] Confirm services start correctly on both an old (Rocky 9.x pre-9.8) and new (Rocky 9.8+/Debian 13) systemd host